### PR TITLE
Added 'InvestorStartup' models and creating tests for her

### DIFF
--- a/forum/investors/models.py
+++ b/forum/investors/models.py
@@ -1,10 +1,14 @@
 from django.db import models
+from django.contrib.auth import get_user_model
+from startups.models import Startup
 from startups.models import Location
 import uuid
 from django.core.validators import MinValueValidator
 from django.core.exceptions import ValidationError
 
 from users.models import User
+
+User = get_user_model()
 
 
 def validate_image_size(value):
@@ -53,3 +57,33 @@ class Investor(models.Model):
 
     def __str__(self):
         return self.company_name
+
+
+class InvestorStartup(models.Model):
+    """
+    Represents a many-to-many relationship between investors and startups, 
+    indicating which investors are following which startups.
+
+    Attributes:
+        investor_id (ForeignKey): A reference to the User model, representing 
+        the investor who follows a startup. The relationship is set to cascade 
+        on deletion, meaning if the user is deleted, their follows will also be removed.
+
+        startup_id (ForeignKey): A reference to the Startup model, representing 
+        the startup being followed by the investor. Like the investor, this relationship 
+        also cascades on deletion.
+
+        saved_at (DateTimeField): A timestamp indicating when the investor 
+        started following the startup. This field is automatically set to 
+        the current date and time when the relationship is created.
+    """
+
+    investor_id = models.ForeignKey(User, on_delete=models.CASCADE, related_name='investor_startups')
+    startup_id = models.ForeignKey(Startup, on_delete=models.CASCADE, related_name='startup_investors')
+    saved_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('investor_id', 'startup_id')
+
+    def __str__(self):
+        return f"{self.investor.username} follows {self.startup.company_name}"

--- a/forum/investors/models.py
+++ b/forum/investors/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import UniqueConstraint
 from django.contrib.auth import get_user_model
 from startups.models import Startup
 from startups.models import Location
@@ -7,8 +8,6 @@ from django.core.validators import MinValueValidator
 from django.core.exceptions import ValidationError
 
 from users.models import User
-
-User = get_user_model()
 
 
 def validate_image_size(value):
@@ -59,7 +58,7 @@ class Investor(models.Model):
         return self.company_name
 
 
-class InvestorStartup(models.Model):
+class InvestorFollow(models.Model):
     """
     Represents a many-to-many relationship between investors and startups, 
     indicating which investors are following which startups.
@@ -77,13 +76,14 @@ class InvestorStartup(models.Model):
         started following the startup. This field is automatically set to 
         the current date and time when the relationship is created.
     """
-
-    investor_id = models.ForeignKey(User, on_delete=models.CASCADE, related_name='investor_startups')
-    startup_id = models.ForeignKey(Startup, on_delete=models.CASCADE, related_name='startup_investors')
+    investor = models.ForeignKey(Investor, on_delete=models.CASCADE)
+    startup = models.ForeignKey(Startup, on_delete=models.CASCADE, related_name='startup_investors')
     saved_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        unique_together = ('investor_id', 'startup_id')
+        constraints = [
+            UniqueConstraint(fields=['investor', 'startup'], name='unique_investor_startup')
+        ]
 
     def __str__(self):
         return f"{self.investor.username} follows {self.startup.company_name}"

--- a/forum/investors/tests.py
+++ b/forum/investors/tests.py
@@ -1,12 +1,13 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from .models import InvestorStartup, Startup, Investor
+from django.db import IntegrityError
+from .models import InvestorFollow, Startup, Investor
 
 User = get_user_model()
 
-class InvestorStartupModelTest(TestCase):
+class InvestorFollowModelTest(TestCase):
     """
-    Test class for validating the functionality of the InvestorStartup model, 
+    Test class for validating the functionality of the InvestorFollow model, 
     which represents the many-to-many relationship between investors (users) 
     and startups. This test suite ensures that investors can follow startups 
     and that duplicate follow relationships cannot be created.
@@ -16,7 +17,7 @@ class InvestorStartupModelTest(TestCase):
         """
         Setup method to initialize the test environment. It creates a user,
         an associated investor profile, and a startup. These objects will be 
-        used in subsequent tests to verify the behavior of the InvestorStartup model.
+        used in subsequent tests to verify the behavior of the InvestorFollow model.
         """
 
         self.user = User.objects.create_user(
@@ -25,13 +26,13 @@ class InvestorStartupModelTest(TestCase):
             password='testpass'
         )
 
-        self.investor_id = Investor.objects.create(
+        self.investor = Investor.objects.create(
             user=self.user,
             company_name="Investor's Company",
             available_funds=100000
         )
 
-        self.startup_id = Startup.objects.create(
+        self.startup = Startup.objects.create(
             user=self.user,
             company_name="Test Startup",
             required_funding=50000
@@ -45,31 +46,31 @@ class InvestorStartupModelTest(TestCase):
         was saved is automatically added.
         """
 
-        relationship = InvestorStartup.objects.create(
-            investor_id=self.user,
-            startup_id=self.startup_id
+        relationship = InvestorFollow.objects.create(
+            investor=self.investor,
+            startup=self.startup
         )
 
-        self.assertEqual(relationship.investor_id, self.user)
-        self.assertEqual(relationship.startup_id, self.startup_id)
+        self.assertEqual(relationship.investor, self.investor)
+        self.assertEqual(relationship.startup, self.startup)
         self.assertIsNotNone(relationship.saved_at)
 
     def test_unique_investor_startup_relationship(self):
         """
         Test that an investor cannot follow the same startup more than once.
-        The test ensures that the uniqueness constraint on the InvestorStartup 
+        The test ensures that the uniqueness constraint on the InvestorFollow
         model prevents the creation of duplicate follow relationships between 
         the same investor and startup.
         """
 
-        InvestorStartup.objects.create(
-            investor_id=self.user,
-            startup_id=self.startup_id
+        InvestorFollow.objects.create(
+            investor=self.investor,
+            startup=self.startup
         )
 
-        with self.assertRaises(Exception):
-            InvestorStartup.objects.create(
-                investor_id=self.user,
-                startup_id=self.startup_id
+        with self.assertRaises(IntegrityError):
+            InvestorFollow.objects.create(
+                investor=self.investor,
+                startup=self.startup
             )
 

--- a/forum/investors/tests.py
+++ b/forum/investors/tests.py
@@ -1,3 +1,75 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from .models import InvestorStartup, Startup, Investor
 
-# Create your tests here.
+User = get_user_model()
+
+class InvestorStartupModelTest(TestCase):
+    """
+    Test class for validating the functionality of the InvestorStartup model, 
+    which represents the many-to-many relationship between investors (users) 
+    and startups. This test suite ensures that investors can follow startups 
+    and that duplicate follow relationships cannot be created.
+    """
+
+    def setUp(self):
+        """
+        Setup method to initialize the test environment. It creates a user,
+        an associated investor profile, and a startup. These objects will be 
+        used in subsequent tests to verify the behavior of the InvestorStartup model.
+        """
+
+        self.user = User.objects.create_user(
+            username='investor1',
+            email='investor1@example.com',
+            password='testpass'
+        )
+
+        self.investor_id = Investor.objects.create(
+            user=self.user,
+            company_name="Investor's Company",
+            available_funds=100000
+        )
+
+        self.startup_id = Startup.objects.create(
+            user=self.user,
+            company_name="Test Startup",
+            required_funding=50000
+        )
+
+    def test_investor_can_follow_startup(self):
+        """
+        Test that an investor (represented by a user) can successfully follow 
+        a startup. The test ensures that the relationship between the investor 
+        and startup is created correctly, and the timestamp for when the startup 
+        was saved is automatically added.
+        """
+
+        relationship = InvestorStartup.objects.create(
+            investor_id=self.user,
+            startup_id=self.startup_id
+        )
+
+        self.assertEqual(relationship.investor_id, self.user)
+        self.assertEqual(relationship.startup_id, self.startup_id)
+        self.assertIsNotNone(relationship.saved_at)
+
+    def test_unique_investor_startup_relationship(self):
+        """
+        Test that an investor cannot follow the same startup more than once.
+        The test ensures that the uniqueness constraint on the InvestorStartup 
+        model prevents the creation of duplicate follow relationships between 
+        the same investor and startup.
+        """
+
+        InvestorStartup.objects.create(
+            investor_id=self.user,
+            startup_id=self.startup_id
+        )
+
+        with self.assertRaises(Exception):
+            InvestorStartup.objects.create(
+                investor_id=self.user,
+                startup_id=self.startup_id
+            )
+


### PR DESCRIPTION
### Pull Request Overview

In this update, I have implemented the `InvestorStartup` model to establish a many-to-many relationship between investors and startups. This model enables us to track which investors follow which startups, enhancing our application's functionality in connecting investors with potential investment opportunities.

### Key Changes:

- **New Model Implementation**: Created the `InvestorStartup` model with the following attributes:
  - `investor_id`: A ForeignKey linking to the User model, representing the investor.
  - `startup_id`: A ForeignKey linking to the Startup model, representing the startup being followed.
  - `saved_at`: A DateTimeField to record when the investor followed the startup, set automatically upon creation.

- **Unique Relationship Constraint**: Added a `unique_together` constraint to ensure that an investor can only follow a startup once, preventing duplicate entries.

- **Documentation**: Included a detailed docstring for the `InvestorStartup` model, describing its purpose, attributes, and methods. This documentation will assist future developers in understanding the model's functionality and usage.

![Test_39-update](https://github.com/user-attachments/assets/fbb6e1c5-67d1-456c-93b8-32099c465f0a)
