### PR TITLE
Add and configure OAuth with Google and GitHub

### DIFF
--- a/forum/forum/settings.py
+++ b/forum/forum/settings.py
@@ -57,6 +57,12 @@ INSTALLED_APPS = [
     'django_extensions',
     'notifications.apps.NotificationsConfig',
     'corsheaders',
+    'django.contrib.sites',  
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.github',
   
 ]
 
@@ -83,6 +89,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
 ]
 
 ROOT_URLCONF = 'forum.urls'
@@ -374,3 +381,31 @@ CORS_ALLOWED_ORIGINS = [
 CSRF_TRUSTED_ORIGINS = [
     'http://localhost:3000',  
 ]
+
+
+SITE_ID = 1
+
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': ['profile', 'email'],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        },
+        'APP': {
+            'client_id': os.environ.get('GOOGLE_CLIENT_ID'),
+            'secret': os.environ.get('GOOGLE_CLIENT_SECRET'),
+            'key': ''
+        }
+    },
+    'github': {
+        'SCOPE': ['user', 'repo'],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        },
+        'APP': {
+            'client_id': os.environ.get('GITHUB_CLIENT_ID'),  
+            'secret': os.environ.get('GITHUB_CLIENT_SECRET'),  
+            'key': ''
+        }
+    }
+}

--- a/forum/forum/urls.py
+++ b/forum/forum/urls.py
@@ -64,6 +64,9 @@ urlpatterns = [
     path('reset_password_sent/', auth_views.PasswordResetDoneView.as_view(), name ='password_reset_done'),
     path('reset/<uidb64>/<token>', auth_views.PasswordResetConfirmView.as_view(), name ='password_reset_confirm'),
     path('reset_password_complete/', auth_views.PasswordResetCompleteView.as_view(), name ='password_reset_complete'),
+
+    # allauth
+     path('accounts/', include('allauth.urls')),
 ]
 
 


### PR DESCRIPTION
This pull request implements OAuth 2.0 authentication using django-allauth for Google and GitHub providers. It configures the required environment variables, callback URLs, and updates the Django settings to include the necessary OAuth providers.

Key Changes:

Installed and configured django-allauth for handling social authentication.
Added Google and GitHub as social providers in Django admin.
Updated INSTALLED_APPS with allauth, allauth.account, allauth.socialaccount, and the respective provider modules.
Set up environment variables for OAuth credentials (client_id and client_secret) for both Google and GitHub.
Configured the required callback URLs for successful OAuth flow (/accounts/google/login/callback/ and /accounts/github/login/callback/).
Added new redirect URIs for local development (localhost:8000) and production environments as needed.
![1](https://github.com/user-attachments/assets/8bb1a0ce-de95-4925-be34-44cc9923cc61)
![2](https://github.com/user-attachments/assets/d1a881e7-04c0-4cbc-908e-8f85d543702d)
![4](https://github.com/user-attachments/assets/3a452f19-5ec5-4c0c-a97a-eaff12fcc840)
![5](https://github.com/user-attachments/assets/1a04da69-db25-47da-a443-7e9e1228ce65)
