### PR TITLE
Added API endpoints to list all startups an investor has saved and to manage these saved entries

### DIFF
--- a/forum/forum/urls.py
+++ b/forum/forum/urls.py
@@ -41,8 +41,8 @@ urlpatterns = [
     path("communications/", include("communications.urls")),
     path("dashboard/", include("dashboard.urls")),
     path("investors/", include("investors.urls")),
-    path("api/startups/", include("startups.urls")),
-    path("api/notifications/", include("notifications.urls")),
+    path("startups/", include("startups.urls")),
+    path("notifications/", include("notifications.urls")),
 
 
 

--- a/forum/startups/admin.py
+++ b/forum/startups/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from .models import Startup
+from .models import Startup, Location
+
 
 @admin.register(Startup)
 class StartupAdmin(admin.ModelAdmin):
@@ -14,7 +15,7 @@ class StartupAdmin(admin.ModelAdmin):
     - Filters the startups by funding stage, location, and number of employees.
     - Orders the startups by creation date, showing the newest ones first.
     - Makes the startup_id and created_at fields read-only in the admin form.
-    
+
     Attributes:
         list_display (tuple): Fields to display in the list view.
         search_fields (tuple): Fields used for the search functionality.
@@ -27,3 +28,27 @@ class StartupAdmin(admin.ModelAdmin):
     list_filter = ('funding_stage', 'location', 'number_of_employees', 'created_at')
     ordering = ('-created_at',)
     readonly_fields = ('startup_id', 'created_at')
+
+
+@admin.register(Location)
+class LocationAdmin(admin.ModelAdmin):
+    """
+    Admin configuration for the Location model.
+
+    Features:
+        - `list_display`: Specifies fields to display in the list view of the admin panel.
+        - `search_fields`: Allows admin users to search for specific entries by city, country, or city code.
+        - `ordering`: Sets the default ordering of entries in the list view by city name.
+        - `list_filter`: Adds a filter sidebar to filter locations by country.
+        
+    Attributes:
+        - list_display (tuple): Fields shown in the list view, providing quick reference to key information.
+        - search_fields (tuple): Fields used for search functionality in the admin panel.
+        - ordering (tuple): Default ordering of entries when displayed in the list view.
+        - list_filter (tuple): Adds filter options in the admin sidebar for filtering by the selected field(s).
+    """
+    
+    list_display = ('location_id', 'city', 'country', 'city_code')
+    search_fields = ('city', 'country', 'city_code')
+    ordering = ('city',)
+    list_filter = ('country',)

--- a/forum/startups/urls.py
+++ b/forum/startups/urls.py
@@ -1,8 +1,16 @@
 from django.urls import path
-from .views import StartupListView, SendMessageView, StartupDetailView
+from .views import (
+    StartupListView,
+    SendMessageView,
+    StartupDetailView,
+    SavedStartupsListAPIView,
+    UnfollowStartupAPIView,
+)
 
 urlpatterns = [
     path('list/', StartupListView.as_view(), name='startups-list'),
     path('message/', SendMessageView.as_view(), name='send_message'),
     path('<startup_id>/', StartupDetailView.as_view(), name='startup-detail'),
+    path('api/v1/investor/saved-startups/', SavedStartupsListAPIView.as_view(), name='saved_startups_list'),
+    path('api/v1/startups/<uuid:startup_id>/unsave/', UnfollowStartupAPIView.as_view(), name='unfollow_startup'),
 ]


### PR DESCRIPTION
he API endpoint for saved startups includes a GET endpoint at /api/investor/saved-startups/, allowing authenticated investors to retrieve a list of their saved startups. Additionally, a DELETE endpoint at /api/startups/<startup_id>/unsave/ enables investors to unfollow previously saved startups. The implementation includes clear error handling for cases where the Investor or InvestorFollow records are missing, and permissions are enforced to ensure only authenticated investors can access or modify their saved startups.

![1](https://github.com/user-attachments/assets/1b083f51-f7df-44b5-bd09-4961108a0425)
![2](https://github.com/user-attachments/assets/11ea170c-4fc6-4f5c-87b6-978c8db6cb0e)
![3](https://github.com/user-attachments/assets/7c9f52a2-a121-4db3-89b7-43304aca6ae5)
![4](https://github.com/user-attachments/assets/66769b0e-f3d4-4abe-a4d7-ccd39e798ca5)
![5](https://github.com/user-attachments/assets/8d60c499-9e75-46d9-b896-9046def5ebb0)
![6](https://github.com/user-attachments/assets/31594f0c-1d11-4edb-8e2f-e4ec09516c27)
![7](https://github.com/user-attachments/assets/369d7e5a-64c9-4b91-84d4-e1e48bc7e56d)
