### PR TITLE
feat: added notification system that alerts investors when there are …

### DIFF
--- a/forum/forum/urls.py
+++ b/forum/forum/urls.py
@@ -30,7 +30,6 @@ from django.http import JsonResponse
 
 
 
-
 urlpatterns = [
     # Admin URL
     path('admin/', admin.site.urls),
@@ -42,7 +41,7 @@ urlpatterns = [
     path("communications/", include("communications.urls")),
     path("dashboard/", include("dashboard.urls")),
     path("investors/", include("investors.urls")),
-    path("api/startups/", include("startups.urls")),
+    path("startups/", include("startups.urls")),
     path("notifications/", include("notifications.urls")),
 
 
@@ -70,8 +69,7 @@ urlpatterns = [
     # allauth
     path('accounts/', include('allauth.urls')),
     path('api/token/oauth/', OAuthTokenObtainPairView.as_view(), name='token_obtain_oauth'),
-
-
+    
 
 ]
 

--- a/forum/investors/serializers.py
+++ b/forum/investors/serializers.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+from notifications.models import Notification
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Notification model.
+
+    This serializer handles the conversion of Notification model instances 
+    into JSON format for API responses and validates incoming data for 
+    Notification creation and updates.
+
+    Fields:
+        All fields from the Notification model are included, as specified 
+        by `fields = '__all__'`.
+    
+    Meta:
+        model (Notification): The model that this serializer serializes.
+        fields (str): Specifies that all fields of the Notification model 
+                      are included in the serialized output.
+    """ 
+    class Meta:
+        model = Notification
+        fields = '__all__'

--- a/forum/investors/urls.py
+++ b/forum/investors/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import SaveStartupView
+from .views import SaveStartupView, InvestorNotificationsAPIView
 
 urlpatterns = [
     path('api/v1/<uuid:startup_id>/save/', SaveStartupView.as_view(), name='save_startup'),
+    path('api/v1/notifications/', InvestorNotificationsAPIView.as_view(), name='investor_notifications'),
 ]

--- a/forum/notifications/models.py
+++ b/forum/notifications/models.py
@@ -54,6 +54,7 @@ class Notification(models.Model):
     is_read = models.BooleanField(default=False)
     read_at = models.DateTimeField(blank=True, null=True)  
     redirection_url = models.URLField(blank=True, null=True)
+    message = models.TextField(blank=True, null=True)
 
     def clean(self):
         """

--- a/forum/notifications/signals.py
+++ b/forum/notifications/signals.py
@@ -42,14 +42,3 @@ def create_project_deleted_notification(sender, instance, **kwargs):
 #             f"Investor '{instance.investor.name}' has followed project '{instance.project.name}'.",
 #             initiator='investor'
 #         )
-
-@receiver(post_save, sender=Startup)
-def create_startup_profile_update_notification(sender, instance, created, **kwargs):
-    if not created:
-        create_notification_task.delay(
-            'startup', 
-            instance.id, 
-            'startup_profile_update', 
-            f"Startup '{instance.name}' has updated its profile.",
-            initiator='startup'
-        )

--- a/forum/startups/apps.py
+++ b/forum/startups/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class StartupsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'startups'
+
+    def ready(self):
+        import startups.signals

--- a/forum/startups/signals.py
+++ b/forum/startups/signals.py
@@ -1,0 +1,53 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Startup
+from notifications.models import Notification
+from investors.models import InvestorFollow
+from notifications.tasks import create_notification_task
+
+
+@receiver(post_save, sender=Startup)
+def notify_investors_on_startup_update(sender, instance, created, **kwargs):
+    """
+    Signal handler to notify investors when a startup's profile is updated or a new post is created.
+    
+    When a `Startup` instance is saved, this function checks if the instance is newly created or updated.
+    If created, it sets a message for a new post. If updated, it generates a message for a profile update.
+    
+    The function then retrieves all investors following the startup and creates a notification for each one.
+    For profile updates, an asynchronous task is triggered to handle additional notification actions.
+    
+    Parameters:
+        sender (Model): The model class sending the signal, `Startup` in this case.
+        instance (Startup): The instance of `Startup` that was created or updated.
+        created (bool): A boolean indicating if the instance is newly created (True) or updated (False).
+        **kwargs: Additional keyword arguments passed to the signal.
+    
+    Notification:
+        Creates a notification entry for each investor following the startup.
+        - If `created` is True, the notification indicates a new post.
+        - If `created` is False, the notification indicates a profile update.
+    
+    Asynchronous Task:
+        If the startup is updated (not created), this function also triggers an asynchronous task to
+        manage further notification processing.
+    """
+
+    followers = InvestorFollow.objects.filter(startup=instance).select_related('investor')
+
+    for follow in followers:
+        Notification.objects.create(
+            investor=follow.investor,
+            startup=instance,
+            trigger='startup_profile_update',
+            redirection_url=f'/startups/{instance.startup_id}/'
+        )
+
+    if not created:
+        create_notification_task.delay(
+            'startup',
+            instance.startup_id,
+            'startup_profile_update',
+            f"Startup '{instance.company_name}' has updated its profile.",
+            initiator='startup'
+        )


### PR DESCRIPTION
This pull request implements a notification system designed to keep investors updated on the activity of startups they follow. A new Notification model was created to store alert information for events like profile updates and new posts. The system triggers notifications through a signal (notify_investors_on_startup_update), which listens for changes on Startup instances. When a startup profile is created or updated, the signal generates notifications for each following investor and triggers an asynchronous task for additional processing.

A new API endpoint (`InvestorNotificationsAPIView`) allows investors to retrieve unread notifications with `GET /api/investor/notifications`, providing timely information on their saved startups. This endpoint utilizes the `NotificationSerializer` to format notification data for the response.

![1](https://github.com/user-attachments/assets/63342436-faae-466f-b87b-57bafc4a1540)
![2](https://github.com/user-attachments/assets/9d296b91-6e96-4df8-9c2d-7e34396d8c99)
![3](https://github.com/user-attachments/assets/b326c0d4-0ae0-453d-813a-f9b239ad601e)
![4](https://github.com/user-attachments/assets/db53a641-8c62-4069-98d3-7a1e4b8e88d1)